### PR TITLE
Fix/safe local storage check

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 The Layer Web SDK is a JavaScript library for adding chat services to your web application. For detailed documentation, tutorials and guides please visit our [Web SDK documentation](https://docs.layer.com/sdk/web-3.0/install).
 
+## Just Starting?
+
+Use our new XDK! The XDK enables a richer messaging experience and new features will be added there. See the repository at [https://github.com/layerhq/web-xdk](https://github.com/layerhq/web-xdk). Don't worry, Layer Web SDK is still supported.
+
 ## Supported Browsers
 
 * IE 11 and Edge

--- a/src/client-authenticator.js
+++ b/src/client-authenticator.js
@@ -144,7 +144,7 @@ class ClientAuthenticator extends Root {
    * @private
    */
   _isPersistedSessionsDisabled() {
-    return !global.localStorage || (this.persistenceFeatures && !this.persistenceFeatures.sessionToken);
+    return !global.isLocalStorageAvailable() || (this.persistenceFeatures && !this.persistenceFeatures.sessionToken);
   }
 
   /**
@@ -722,7 +722,7 @@ class ClientAuthenticator extends Root {
 
 
   _clearStoredData(callback) {
-    if (global.localStorage) localStorage.removeItem(LOCALSTORAGE_KEYS.SESSIONDATA + this.appId);
+    if (global.isLocalStorageAvailable()) localStorage.removeItem(LOCALSTORAGE_KEYS.SESSIONDATA + this.appId);
     if (this.dbManager) {
       this.dbManager.deleteTables(callback);
     } else if (callback) {
@@ -745,7 +745,7 @@ class ClientAuthenticator extends Root {
 
     if (this.sessionToken) {
       this.sessionToken = '';
-      if (global.localStorage) {
+      if (global.isLocalStorageAvailable()) {
         localStorage.removeItem(LOCALSTORAGE_KEYS.SESSIONDATA + this.appId);
       }
     }
@@ -1093,7 +1093,7 @@ class ClientAuthenticator extends Root {
           logger.warn('SESSION EXPIRED!');
           this.isAuthenticated = false;
           this.isReady = false;
-          if (global.localStorage) localStorage.removeItem(LOCALSTORAGE_KEYS.SESSIONDATA + this.appId);
+          if (global.isLocalStorageAvailable()) localStorage.removeItem(LOCALSTORAGE_KEYS.SESSIONDATA + this.appId);
           this.trigger('deauthenticated');
           this._authenticate(result.data.getNonce());
         }

--- a/src/root.js
+++ b/src/root.js
@@ -12,6 +12,15 @@ const Logger = require('./logger');
 function EventClass() { }
 EventClass.prototype = Events;
 
+global.isLocalStorageAvailable = () => {
+  try { 
+    test = Storage; //this will fail if Storage doesn't exist
+    return global.localStorage instanceof Storage; 
+  } catch(e) { 
+    return false; 
+  }
+};
+
 const SystemBus = new EventClass();
 if (typeof postMessage === 'function') {
   addEventListener('message', (event) => {

--- a/src/telemetry-monitor.js
+++ b/src/telemetry-monitor.js
@@ -39,7 +39,7 @@ class TelemetryMonitor extends Root {
     this.tempState = {};
     this.storageKey = 'layer-telemetry-' + this.client.appId;
 
-    if (!global.localStorage) {
+    if (!global.isLocalStorageAvailable()) {
       this.enabled = false;
     } else {
       try {


### PR DESCRIPTION
When using other dependencies that override completely the global `localStorage` instance, Layer SDK will fail on the `telemetry` and `client-authentication` workflow.

To fix this, a different check was added to ensure that the `localStorage` that is used by Layer is actually a `Storage` prototype instance. 