### PR TITLE
Fix an issue with marking announcements as read

### DIFF
--- a/src/models/conversation-message.js
+++ b/src/models/conversation-message.js
@@ -218,7 +218,8 @@ class ConversationMessage extends Message {
    */
   __updateIsRead(value) {
     if (value) {
-      if (!this._inPopulateFromServer && !this.getConversation()._inMarkAllAsRead) {
+      const conv = this.getConversation()
+      if (!this._inPopulateFromServer && (!conv || !conv._inMarkAllAsRead)) {
         this._sendReceipt(Constants.RECEIPT_STATE.READ);
       }
       this._triggerMessageRead();


### PR DESCRIPTION
This pull request fixes an crashing issue when marking announcements as read. 

The `Announcement` class overrides the `getConversation` method to be a no-op; the return value is `undefined` in this situation. This means `this.getConversation()._inMarkAllAsRead` will always raise an exception for Announcements since we're trying to access a property on `undefined`. 