### PR TITLE
Catch errors on query result and trigger error callback

### DIFF
--- a/src/queries/query.js
+++ b/src/queries/query.js
@@ -450,19 +450,23 @@ class Query extends Root {
     if (requestUrl !== this._firingRequest || this.isDestroyed) return;
 
     // isFiring is false... unless we are still syncing
-    this.isFiring = false;
-    this._firingRequest = '';
-    if (results.success) {
-      this.totalSize = Number(results.xhr.getResponseHeader('Layer-Count'));
-      if (results.data.length < pageSize || results.data.length === this.totalSize) this.pagedToEnd = true;
-      this._appendResults(results, false);
+    try {
+      this.isFiring = false;
+      this._firingRequest = '';
+      if (results.success) {
+        this.totalSize = Number(results.xhr.getResponseHeader('Layer-Count'));
+        if (results.data.length < pageSize || results.data.length === this.totalSize) this.pagedToEnd = true;
+        this._appendResults(results, false);
 
-    } else if (results.data.getNonce()) {
-      this.client.once('ready', () => {
-        this._run();
-      });
-    } else {
-      this.trigger('error', { error: results.data });
+      } else if (results.data.getNonce()) {
+        this.client.once('ready', () => {
+          this._run();
+        });
+      } else {
+        this.trigger('error', { error: results.data });
+      }
+    } catch (error) {
+      this.trigger('error', { error });
     }
   }
 

--- a/src/queries/query.js
+++ b/src/queries/query.js
@@ -450,23 +450,19 @@ class Query extends Root {
     if (requestUrl !== this._firingRequest || this.isDestroyed) return;
 
     // isFiring is false... unless we are still syncing
-    try {
-      this.isFiring = false;
-      this._firingRequest = '';
-      if (results.success) {
-        this.totalSize = Number(results.xhr.getResponseHeader('Layer-Count'));
-        if (results.data.length < pageSize || results.data.length === this.totalSize) this.pagedToEnd = true;
-        this._appendResults(results, false);
+    this.isFiring = false;
+    this._firingRequest = '';
+    if (results.success) {
+      this.totalSize = Number(results.xhr.getResponseHeader('Layer-Count'));
+      if (results.data.length < pageSize || results.data.length === this.totalSize) this.pagedToEnd = true;
+      this._appendResults(results, false);
 
-      } else if (results.data.getNonce()) {
-        this.client.once('ready', () => {
-          this._run();
-        });
-      } else {
-        this.trigger('error', { error: results.data });
-      }
-    } catch (error) {
-      this.trigger('error', { error });
+    } else if (results.data.getNonce && results.data.getNonce()) {
+      this.client.once('ready', () => {
+        this._run();
+      });
+    } else {
+      this.trigger('error', { error: results.data });
     }
   }
 


### PR DESCRIPTION
###### SUMARY
This PR is related to [this](https://github.com/Feeld/feeld-reactnative/pull/969). 

When query is executed when there is no connection it tends to fail on **_processRunResults** function with an error: **undefined is not a function (evaluating 't.data.getNonce()')**

##### COMPLETED TASKS
- Added try catch for entire function and trigger error warning on catched error.